### PR TITLE
feat-sync: Phase3 buffering tolerance

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -24,9 +24,9 @@ HTML_OUTPUT            = .
 GENERATE_LATEX         = NO
 RECURSIVE              = NO
 FULL_PATH_NAMES        = NO
-INPUT                  = app.js \
-                         background.js \
-                         README.md
+INPUT                  = scripts/main.js \
+                         README.md \
+                         docs/
 FILE_PATTERNS          = *.js \
                          *.md
 EXTENSION_MAPPING      = js=JavaScript


### PR DESCRIPTION
## Summary
- add buffering and seek cooldown logic to reconcile
- extend SYNC_SETTINGS with recoveryToleranceMs, bufferGraceMs, seekCooldownMs, staleThresholdMs

## Testing
- npm run lint